### PR TITLE
bootstrap 固有の css class for table は helper で共通化

### DIFF
--- a/app/views/artists/show.html.erb
+++ b/app/views/artists/show.html.erb
@@ -5,7 +5,7 @@
 <h1><%= @artist.name %></h1>
 
 <% if @artist.songs.size > 0 -%>
-<table class='table table-striped table-bordered table-condensed'>
+<table class="<%= table_css_classes -%>">
   <thead>
   <tr>
     <th><%= Song.human_attribute_name('name') -%></th>


### PR DESCRIPTION
table いくつもあって bootstrap に変更あったときに個別に変えるの面倒なので helper で共通化する
