### PR TITLE
曲を保存する際に新規作成したアーティストと紐付けるようにする

### DIFF
--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -58,7 +58,7 @@ class Song < ActiveRecord::Base
     if artist_name.present?
       artist = Artist.new name: artist_name
       artist.save!
-      artist.id
+      self.artist_id = artist.id
     end
   end
 end

--- a/spec/models/song_spec.rb
+++ b/spec/models/song_spec.rb
@@ -108,6 +108,10 @@ describe Song do
           it 'create artist' do
             expect(Artist.where(name: 'Garnet Crow').present?).to be true
           end
+
+          it 'song belong to the artist' do
+            expect(song.artist.name).to eq(song.artist_name)
+          end
         end
       end
     end


### PR DESCRIPTION
## 修正内容
- 曲を保存するフォームで「新規アーティスト作成」する機能がある
- アーティスト作成されるが、保存した曲と紐付けされない不具合があった
- 本PRはその不具合の修正
