### PR TITLE
Fix DEPRECATION WARNING in factories

### DIFF
--- a/spec/factories/artists.rb
+++ b/spec/factories/artists.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     sequence(:name) { |n| "artist#{n}" }
 
     factory :invalid_artist do
-      name nil
+      name { nil }
     end
   end
 end

--- a/spec/factories/songs.rb
+++ b/spec/factories/songs.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     end
 
     factory :invalid_song do
-      name nil
+      name { nil }
     end
   end
 end


### PR DESCRIPTION
```
DEPRECATION WARNING: Static attributes will be removed in FactoryBot
5.0. Please use dynamic
attributes instead by wrapping the attribute value in a block:

name { nil }
```