### PR TITLE
specify parser version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,8 @@ gem 'dotenv-rails'
 
 gem 'bootsnap', require: false
 
+gem 'parser', '~> 2.5.1.0'
+
 group :development do
   # application process manager
   gem 'foreman'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -187,7 +187,7 @@ GEM
     notiffany (0.1.1)
       nenv (~> 0.1)
       shellany (~> 0.0)
-    parser (2.5.3.0)
+    parser (2.5.1.2)
       ast (~> 2.4.0)
     pg (0.21.0)
     popper_js (1.14.3)
@@ -339,6 +339,7 @@ DEPENDENCIES
   launchy
   marco-polo
   nokogiri (>= 1.8.2)
+  parser (~> 2.5.1.0)
   pg (~> 0.21)
   pry-rails
   puma


### PR DESCRIPTION
2.5.3だと `warning: 2.5.3-compliant syntax, but you are running 2.5.1.`  エラーとなる